### PR TITLE
ifort compiler flags fixed

### DIFF
--- a/configure
+++ b/configure
@@ -2221,17 +2221,9 @@ $as_echo "$ac_cv_prog_fc_g" >&6; }
 if test "$ac_test_FCFLAGS" = set; then
   FCFLAGS=$ac_save_FCFLAGS
 elif test $ac_cv_prog_fc_g = yes; then
-  if test "x$ac_cv_fc_compiler_gnu" = xyes; then
     FCFLAGS="-g -O2"
-  else
-    FCFLAGS="-g"
-  fi
 else
-  if test "x$ac_cv_fc_compiler_gnu" = xyes; then
     FCFLAGS="-O2"
-  else
-    FCFLAGS=
-  fi
 fi
 
 if test $ac_compiler_gnu = yes; then


### PR DESCRIPTION
from ifort manpage:

```
option -g (Linux* OS and OS X*) and /Zi or /Z7 (Windows* OS), which  changes
the default optimization level from O2 to -O0 (Linux OS and OS X) or /Od
(Windows OS). You can override this effect by explicitly specifying an O option
setting.
```

therefore if the optimization should be enabled it should be
stated explicitly

for example:
`./configure FC=ifort ; make -n`
shows FCFLAGS without `-O`. By default ifort switch to `-O2` but that is not the case when optioin `-g` is set. So  `-O2` needs to be given or option `-g` should not be used.

This has big speed impact. On my machine:
`./configure FC=ifort ; make run`

currently gives: 29 min
when `-O2` is given: 6 min
if omp is enabled.
