### PR TITLE
Create a Dockerfile for a SELEN buildenv

### DIFF
--- a/docker/selen-buildenv-bionic/Dockerfile
+++ b/docker/selen-buildenv-bionic/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+RUN apt update && \
+  DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt install --yes \
+  build-essential \
+  gfortran \
+  gmt \
+  gmt-gshhg

--- a/docker/selen-buildenv-bionic/README.md
+++ b/docker/selen-buildenv-bionic/README.md
@@ -1,0 +1,1 @@
+Build environment for SELEN using the Ubuntu Bionic (18.04) Docker container.


### PR DESCRIPTION
This Dockerfile will be used to create a build environment for SELEN. Dockerfiles make it easy to be explicit about environment requirements, and containers are easily sandboxed, ensuring useful testing results. Having the Dockerfile in the repository makes it simple to update, allows developers and users to be sure about dependencies, and means that we can use [DockerHub](https://dockerhub.com/u/geodynamics) to automatically build and distribute the container.

CIG's Jenkins server can be found at [https://jenkins.geodynamics.org](https://jenkins.geodynamics.org).